### PR TITLE
[DOCS] Update to XML. [ENHANCEMENT] Added HEXA parser, and loose versions of HEX and HEXA parser

### DIFF
--- a/Farbe.fs
+++ b/Farbe.fs
@@ -42,22 +42,34 @@ module internal ColorUtil =
             lastHue, s, l
 
 
-    /// Point must be at middle of expression: like this: min <=. x .<= max
+    /// <summary>
+    /// Point must be at middle of expression: like this: <c>min &lt;=. x .&lt;= max</c>
+    /// </summary>
     let inline ( <=.) left middle = (left <= middle, middle)
 
-    /// Point must be at middle of expression: like this: min <. x .< max
+    /// <summary>
+    /// Point must be at middle of expression: like this: <c>min &lt;. x .&lt; max</c>
+    /// </summary>
     let inline ( <. ) left middle = (left < middle, middle)
 
-    /// Point must be at middle of expression: like this: min <. x .< max
+    /// <summary>
+    /// Point must be at middle of expression: like this: <c>min &lt;. x .&lt; max</c>
+    /// </summary>
     let inline ( .< ) (leftResult, middle) right = leftResult && (middle < right)
 
-    /// Point must be at middle of expression: like this: min <=. x .<= max
+    /// <summary>
+    /// Point must be at middle of expression: like this: <c>min &lt;=. x .&lt;= max</c>
+    /// </summary>
     let inline ( .<= ) (leftResult, middle) right = leftResult && (middle <= right)
 
-    /// For inner expressions: like this: min <. x .<. y .< max
+    /// <summary>
+    /// For inner expressions: like this: <c>min &lt;. x .&lt;. y .&lt; max</c>
+    /// </summary>
     let inline ( .<. ) (leftResult, middle) right = leftResult && (middle < right), right
 
-    /// for inner expressions: like this: min <. x .<. y .< max
+    /// <summary>
+    /// For inner expressions: like this: <c>min &lt;=. x .&lt;=. y .&lt;= max</c>
+    /// </summary>
     let inline ( .<=. ) (leftResult, middle) right = leftResult && (middle <= right), right
 
     type ArgumentException with

--- a/Parse.fs
+++ b/Parse.fs
@@ -30,17 +30,80 @@ module ParseFarbe =
         | 'd' -> 13
         | 'e' -> 14
         | 'f' -> 15
-        | _ -> raise ( ArgumentException $"ParseFrabe: Invalid hex character '{c}'" )
+        | _ -> raise ( ArgumentException $"ParseFarbe: Invalid hex character '{c}'" )
 
     let parseHexPair(h1:Char, h2:Char) =
         parseHex(h1) * 16 + parseHex(h2)
 
-
-    let parseHexColor(s:string) =
-        if s.Length <> 7 then
-            raise ( ArgumentException $"ParseFrabe: Invalid hex color '{s}'" )
-        else
+    /// <summary>
+    /// Parses 'HEX' strings (with or without '#').
+    /// </summary>
+    /// <remarks>
+    /// When encountering a 'HEXA' string, it will ignore the <c>alpha</c> value (without validation).
+    /// </remarks>
+    let looseParseHexColor(s: string) =
+        match s[0] with
+        | _ when s.Length = 6 || s.Length = 8 ->
+            let r = parseHexPair(s.[0], s.[1])
+            let g = parseHexPair(s.[2], s.[3])
+            let b = parseHexPair(s.[4], s.[5])
+            r, g, b
+        | '#' when s.Length = 7 || s.Length = 9 ->
             let r = parseHexPair(s.[1], s.[2])
             let g = parseHexPair(s.[3], s.[4])
             let b = parseHexPair(s.[5], s.[6])
             r, g, b
+        | _ ->
+            raise ( ArgumentException $"ParseFarbe: Invalid hex color '{s}'" )
+
+    /// <summary>
+    /// Parses 'HEXA' strings (with or without '#').
+    /// </summary>
+    /// <remarks>
+    /// When encountering a 'HEX' string, it will default <c>alpha</c> to <c>255</c>.
+    /// </remarks>
+    let looseParseHexaColor(s: string) =
+        match s[0] with
+        | _ when s.Length = 6 ->
+            let r = parseHexPair(s.[0], s.[1])
+            let g = parseHexPair(s.[2], s.[3])
+            let b = parseHexPair(s.[4], s.[5])
+            r, g, b, 255
+        | _ when s.Length = 8 ->
+            let r = parseHexPair(s.[0], s.[1])
+            let g = parseHexPair(s.[2], s.[3])
+            let b = parseHexPair(s.[4], s.[5])
+            let a = parseHexPair(s.[6], s.[7])
+            r, g, b, a
+        | '#' when s.Length = 7 ->
+            let r = parseHexPair(s.[1], s.[2])
+            let g = parseHexPair(s.[3], s.[4])
+            let b = parseHexPair(s.[5], s.[6])
+            r, g, b, 255
+        | '#' when s.Length = 9 ->
+            let r = parseHexPair(s.[1], s.[2])
+            let g = parseHexPair(s.[3], s.[4])
+            let b = parseHexPair(s.[5], s.[6])
+            let a = parseHexPair(s.[7], s.[8])
+            r, g, b, a
+        | _ ->
+            raise ( ArgumentException $"ParseFarbe: Invalid hex color '{s}'" )
+    
+    let parseHexColor(s:string) =
+        if s.Length <> 7 then
+            raise ( ArgumentException $"ParseFarbe: Invalid hex color '{s}'")
+        else 
+            let r = parseHexPair(s.[1], s.[2])
+            let g = parseHexPair(s.[3], s.[4])
+            let b = parseHexPair(s.[5], s.[6])
+            r, g, b        
+    
+    let parseHexaColor(s: string) =
+        if s.Length <> 9 then
+            raise ( ArgumentException $"ParseFarbe: Invalid hexa color '{s}'")
+        else
+            let r = parseHexPair(s.[1], s.[2])
+            let g = parseHexPair(s.[3], s.[4])
+            let b = parseHexPair(s.[5], s.[6])
+            let a = parseHexPair(s.[7], s.[8])
+            r,g,b,a


### PR DESCRIPTION
DOCS: Updated docs with inline code to use XML docs for proper rendering on Rider
ADD: Added 'loose' parsers of hex and hexa colors.
ADD: Added hexa parser.

---

The main use case for the HEXA/HEX loose parsers is just so I can be more forgiving to API users.